### PR TITLE
Fix the bug that candidates that are not extracted from the original cause an error

### DIFF
--- a/bin/automan_archiver.py
+++ b/bin/automan_archiver.py
@@ -94,6 +94,9 @@ class AutomanArchiver(object):
         if 200 > res.status_code >= 300:
             print(f'get annotation image status_code = {res.status_code}. body = {res.text}')
             return None
+        if res.status_code >= 300:
+            print(f'Failed to get data of candidate-id {candidate_id} at frame {frame}')
+            return None
 
         # write images
         os.makedirs(images_dir, exist_ok=True)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Other

## Description
This patch fixes the bug that the archiver fails when it receives candidate-data with status-code >= 300

